### PR TITLE
Fix interaction handling on direct messages

### DIFF
--- a/discord/discordInteraction.js
+++ b/discord/discordInteraction.js
@@ -60,8 +60,14 @@ module.exports = function (RED) {
           let message = {};
           message.payload = Flatted.parse(Flatted.stringify(interaction));
           message.payload.user = Flatted.parse(Flatted.stringify(interaction.user));
-          message.payload.member = Flatted.parse(Flatted.stringify(interaction.member));
-          message.payload.member.guild = Flatted.parse(Flatted.stringify(interaction.member.guild));
+
+          if(interaction.member !== null) {
+            message.payload.member = Flatted.parse(Flatted.stringify(interaction.member));
+            message.payload.member.guild = Flatted.parse(Flatted.stringify(interaction.member.guild));
+          }
+          else {
+            message.payload.member = null;
+          }
 
           if (injectInteractionObject)
             message.interactionObject = interaction;


### PR DESCRIPTION
When an interaction on a direct message is received the discordInteraction node would fail as it tries to read guild (and member) information from the message.
This PR fixes this edge case and the returned message will have its 'member' property set to null just as the message received from the discord api.