### PR TITLE
Remove references to now deprecated timedelay functionaliry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog\
 
-## [Unreleased]
+## 3.3.2
 * Feature - React 'action' to messages on discordMessageManager by Unicode or name of custom guild emoji (action='react').
 * Feature - Reply 'action' for messages on discordMessageManager (action='reply').
 * Hotfix - discordMessageManager not sending messages when embeds is an array.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Currently the following actions are supported:
 * Send private messages to users.
 * Send and edit embed messages.
 * Add attachments to messages.
-* Edit messages in a channel.
-* Delete messages in a channel.
+* Edit, reply, delete messages in a channel.
+* React to messages with emojis.
 * Listen for reactions on a message.
 * Listen for interactions on a message button or select menu.
 * Listen for interactions on commands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-discord-advanced",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-discord-advanced",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^13.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-discord-advanced",
-  "version": "3.3.1",
-  "description": "Recieve, send (to channel or private), edit and delete Discord (embed) messages in Node-RED.",
+  "version": "3.3.2",
+  "description": "Recieve, send, edit, reply, react to and delete Discord messages, handle interactions and much more in Node-RED.",
   "main": "discord/discord.js",
   "scripts": {
     "test": "mocha \"test/**/*_spec.js\""


### PR DESCRIPTION
Remove references to the timedelay when using the delete action with a message