### PR TITLE
Update discordInteractionManager.js

### DIFF
--- a/discord/discordInteractionManager.js
+++ b/discord/discordInteractionManager.js
@@ -99,7 +99,7 @@ module.exports = function (RED) {
                         case 'edit':
                             await editInteractionReply();
                             break;
-                        case 'respondautocomplete':
+                        case 'respond':
                             await respondAutocomplete();
                             break;
                         default:


### PR DESCRIPTION
Changed `action` switch case for respond to match the wiki. Previously was `respondautocomplete` changed to `respond`.