### PR TITLE
Added new nodes: Guild Manager, Event Manager, and message search functionality

### DIFF
--- a/discord/discordEventManager.html
+++ b/discord/discordEventManager.html
@@ -1,0 +1,104 @@
+a<script type="text/javascript">
+  RED.nodes.registerType('discordEventManager', {
+    category: 'discord',
+    color: '#7289da',
+    defaults: {
+      name: {
+        value: "",
+        required: false
+      },
+      guild: {
+        value: null,
+        required: false
+      },
+      event: {
+        value: null,
+        required: false
+      },
+      token: {
+        value: "",
+        required: true,
+        type: "discord-token"
+      }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: "discord.png",
+    label: function () {
+      return this.name || "discordEventManager";
+    }
+  });
+</script>
+<script type="text/x-red" data-template-name="discordEventManager">
+  <div class="form-row">
+        <label for="node-input-token"><i class="icon-tag"></i> token</label>
+        <input type="text" id="node-input-token" placeholder="token">
+    </div>
+    <div class="form-row">
+        <label for="node-input-guild"><i class="icon-tag"></i> Guild</label>
+        <input type="text" id="node-input-guild" name="ch" placeholder="Guild ID">
+        <p>(leave 'guild' blank to use <code>msg.guild</code> as Guild ID)</p>
+    </div>
+    <div class="form-row">
+      <label for="node-input-event"><i class="icon-tag"></i> Event</label>
+      <input type="text" id="node-input-event" name="ch" placeholder="Event ID">
+      <p>(leave 'event' blank to use <code>msg.event</code> as Event ID)</p>
+  </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+<script type="text/x-red" data-help-name="discordEventManager">
+  <p>Node to create, delete scheduled events as well as obtain info about a specific event or all events in a guild.</p>
+
+  <h3>Inputs</h3>
+  <dl class="message-properties">
+    <dt>action
+      <span class="property-type">string</span>
+    </dt>
+    <dd>The action to do, can be: create, delete, info, all. If not set, node will default to info.</dd>
+    <dt>guild
+      <span class="property-type">Object or string</span>
+    </dt>
+    <dd>The guild Object or channel id for creating, obtaining and deleting events.</dd>
+    <dt>event
+      <span class="property-type">Object or string</span>
+    </dt>
+    <dd>The event Object or channel id for obtaining and deleting events.</dd>
+  </dl>
+
+  <h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>payload
+      <span class="property-type">Object</span>
+    <dt>
+    <dd>The event that was created, obtained, or deleted. In the case of search for all events, payload will be an array of events.</dd>
+  </dl>
+
+  <h3>Details</h3>
+  <p>Node to create, delete scheduled events as well as obtain info about a specific event or all events in a guild.</p>
+
+  <h4>Obtaining event info</h4>
+  <p>When obtaining info an event both <code>msg.event</code> and <code>msg.guild</code> are required. The output will be the raw event data provided by discord JS.<p>
+
+  <h4>Obtaining all events<h4>
+  <p>When obtaining all the events in a guild <code>msg.guild</code> is required. The output will be an array of events provided by discord JS.</p>
+
+  <h4>Deleting events</h4>
+  <p>When deleting an event both <code>msg.event</code> and <code>msg.guild</code> are required.<p>
+
+
+  <h4>Creating events</h4>
+  <p>Creating an event requires many provided fields, namely: <code>msg.event</code>, <code>msg.eventName</code>, <code>msg.eventScheduledStartTime</code>, and <code>msg.eventType</code>.
+    When <code>msg.eventType</code> is set to 'external', then <code>msg.eventLocation</code> must be provided as well as <code>msg.eventScheduledEndTime</code>.
+    When <code>msg.eventType</code> is set to 'voice', then <code>msg.eventChannel</code> must be provided, where the eventChannel is the ID of the corrosponding voice channel
+
+    Both <code>msg.eventScheduledStartTime</code> and <code>msg.eventScheduledEndTime</code> are parsed directly as javascript Date object. The Date object can take miliseconds directly as the date object. 
+    <code>msg.reason</code> and <code>msg.description</code> are optional fields.
+    
+  <p>
+
+
+
+</script>

--- a/discord/discordEventManager.js
+++ b/discord/discordEventManager.js
@@ -1,0 +1,202 @@
+module.exports = function (RED) {
+  var discordBotManager = require('./lib/discordBotManager.js');
+  var discordFramework = require('./lib/discordFramework.js');
+  const Flatted = require('flatted');
+  const {
+    GuildScheduledEventEntityType,
+    GuildScheduledEventPrivacyLevel,
+  } = require('discord.js');
+
+
+  function discordEventManager(config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
+    var configNode = RED.nodes.getNode(config.token);
+
+    discordBotManager.getBot(configNode).then(function (bot) {
+      node.on('input', async function (msg, send, done) {
+        
+        const _guildID = config.guild || msg.guild || null;
+        const _eventID = config.event || msg.event || null;
+        const _action = msg.action || "info";
+
+        const _eventName = msg.eventName || null;
+        const _eventScheduledStartTime = msg.scheduledStartTime || null;
+        const _eventScheduledEndTime = msg.scheduledEndTime || null;
+        const _eventEventType = msg.eventType || "external";
+        const _eventChannel = msg.channel || null;
+        const _eventImage = null; //To-do.....
+        const _eventReason = msg.reason || null;
+        const _eventDescription = msg.description || null;
+        const _eventLocation = msg.eventLocation || null;
+
+        const setError = (error) => {
+          node.status({
+            fill: "red",
+            shape: "dot",
+            text: error
+          })
+          done(error);
+        }
+
+        const setSuccess = (succesMessage, data) => {
+          node.status({
+            fill: "green",
+            shape: "dot",
+            text: succesMessage
+          });
+
+          msg.payload = Flatted.parse(Flatted.stringify(data));
+          send(msg);
+          done();
+        }
+
+        
+
+        const infoEvent = async () => {
+          try {
+            let eventManager = await discordFramework.getEventManager(bot, _guildID)
+
+            const eventID = discordFramework.checkIdOrObject(_eventID);
+
+            let event = await eventManager.fetch(eventID)
+
+            setSuccess(`event ${event.id} info obtained`, event);
+          } catch (err) {
+            setError(err);
+          }
+        }
+
+        const getEvents = async () => {
+          try {
+            let eventManager = await discordFramework.getEventManager(bot, _guildID)
+
+            let events = await eventManager.fetch()
+
+            setSuccess(`events [${events.size}] obtained`, events);
+          } catch (err) {
+            setError(err);
+          }
+        }
+
+        const deleteEvent = async () => {
+          try {
+            let eventManager = await discordFramework.getEventManager(bot, _guildID)
+
+            const eventID = discordFramework.checkIdOrObject(_eventID);
+
+            let event = await eventManager.fetch(eventID)
+            let deleted = await eventManager.delete(event)
+
+            setSuccess(`event ${event.id} deleted`, deleted);
+          } catch (err) {
+            setError(err);
+          }
+        }
+
+        const createEvent = async () => {
+
+          try {
+
+            let eventManager = await discordFramework.getEventManager(bot, _guildID)
+            const eventName = discordFramework.checkIdOrObject(_eventName)
+            const eventChannel = discordFramework.checkIdOrObject(_eventChannel)
+            
+
+            if (!eventName) {
+              throw (`msg.eventName wasn't set correctly`);
+            }
+
+            if (_eventScheduledStartTime == null) {
+              throw (`msg.scheduledStartTime wasn't set correctly`);
+            }
+
+            if ( _eventEventType == "external" ){
+
+              if ( _eventLocation == null ){
+
+                throw (`msg.eventLocation wasn't set correctly, is required when event type is set to external`);
+
+              }
+
+              if ( _eventScheduledEndTime == null ){
+
+                throw (`msg.eventScheduledEndTime wasn't set correctly, is required when event type is set to external`);
+
+              }
+
+            }
+            else if ( _eventEventType == "voice" ){
+
+              if ( !eventChannel ){
+
+                throw (`msg.channel wasn't set correctly, is required when event type is set to voice`);
+
+              }
+
+            }
+            else {
+
+              throw (`msg.eventType wasn't set correctly, ${_eventEventType} is not a valid event type`)
+
+            }
+
+            const eventMetadata = {
+              location: _eventLocation
+            };
+            
+            eventScheduledEndTime = new Date(_eventScheduledEndTime) || null 
+
+            let event = await eventManager.create({
+              name: eventName,
+              scheduledStartTime: new Date(_eventScheduledStartTime),
+              scheduledEndTime: new Date(eventScheduledEndTime),
+              privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+              entityType: _eventEventType == "voice" ? GuildScheduledEventEntityType.Voice : GuildScheduledEventEntityType.External,
+              description: _eventDescription,
+              channel: _eventChannel,
+              image: null,
+              reason: _eventReason,
+              entityMetadata: eventMetadata
+            });
+
+            setSuccess(`event ${event.id} created`, event);
+          } catch (err) {
+            setError(err);
+          }
+        }
+
+
+
+        switch (_action.toLowerCase()) {
+          case 'info':
+            await infoEvent();
+            break;
+          case 'all':
+              await getEvents();
+              break;
+          case 'create':
+            await createEvent();
+            break;
+          case 'delete':
+            await deleteEvent();
+            break;
+          default:
+            setError(`msg.action has an incorrect value`)
+        }
+
+        node.on('close', function () {
+          discordBotManager.closeBot(bot);
+        });
+      });
+    }).catch(err => {
+      console.log(err);
+      node.status({
+        fill: "red",
+        shape: "dot",
+        text: err
+      });
+    });
+  }
+  RED.nodes.registerType("discordEventManager", discordEventManager);
+};

--- a/discord/discordGuildManager.html
+++ b/discord/discordGuildManager.html
@@ -1,0 +1,75 @@
+a<script type="text/javascript">
+  RED.nodes.registerType('discordGuildManager', {
+    category: 'discord',
+    color: '#7289da',
+    defaults: {
+      name: {
+        value: "",
+        required: false
+      },
+      guild: {
+        value: null,
+        required: false
+      },
+      token: {
+        value: "",
+        required: true,
+        type: "discord-token"
+      }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: "discord.png",
+    label: function () {
+      return this.name || "discordGuildManager";
+    }
+  });
+</script>
+<script type="text/x-red" data-template-name="discordGuildManager">
+  <div class="form-row">
+        <label for="node-input-token"><i class="icon-tag"></i> token</label>
+        <input type="text" id="node-input-token" placeholder="token">
+    </div>
+    <div class="form-row">
+        <label for="node-input-guild"><i class="icon-tag"></i> Guild</label>
+        <input type="text" id="node-input-guild" name="guild" placeholder="Guild ID">
+        <p>(leave 'guild' blank to use <code>msg.guild</code> as guild ID to send to)</p>
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+<script type="text/x-red" data-help-name="discordGuildManager">
+  <p>Node to retrieve info from a guild, as well as an action to rename the guild.</p>
+
+  <h3>Inputs</h3>
+  <dl class="message-properties">
+    <dt>action
+      <span class="property-type">string</span>
+    </dt>
+    <dd>The action to do, can be: name, info. If not set, node will default to info.</dd>
+    <dt>guild
+      <span class="property-type">Object or string</span>
+    </dt>
+    <dd>The guild object or ID.</dd>
+    <dt>name 
+      <span class="property-type">string</span>
+    </dt>
+    <dd>The new name of the guild if performing the name operation.</dd>
+  </dl>
+
+  <h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>payload
+      <span class="property-type">Object</span>
+    <dt>
+    <dd>The guild object containing all of the information listed in discord JS guild class</dd>
+  </dl>
+
+  <h3>Details</h3>
+  <p>This node provides information on a given guild, it can also rename the guild.<p>
+
+  <h4>Renaming the guild<h4>
+  <p>To rename the guild you must set <code>msg.name</code> as the name you desire to set the guild to as a string.</p>
+</script>

--- a/discord/discordGuildManager.js
+++ b/discord/discordGuildManager.js
@@ -1,0 +1,124 @@
+module.exports = function (RED) {
+  var discordBotManager = require('node-red-contrib-discord-advanced/discord/lib/discordBotManager.js');
+  var messagesFormatter = require('node-red-contrib-discord-advanced/discord/lib/messagesFormatter.js');
+  const Flatted = require('flatted');
+  const {
+    ChannelType
+  } = require('discord.js');
+
+  const checkString = (field) => typeof field === 'string' ? field : false;
+
+  function discordMessageManager(config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
+    var configNode = RED.nodes.getNode(config.token);
+
+    discordBotManager.getBot(configNode).then(function (bot) {
+      node.on('input', async function (msg, send, done) {
+        const _guild = config.guild || msg.guild || null;
+        const _action = msg.action || 'info';
+
+        const _name = msg.name || null;
+      
+
+        const setError = (error) => {
+          node.status({
+            fill: "red",
+            shape: "dot",
+            text: error
+          })
+          done(error);
+        }
+
+        const setSuccess = (succesMessage, data) => {
+          node.status({
+            fill: "green",
+            shape: "dot",
+            text: succesMessage
+          });
+
+          msg.payload = Flatted.parse(Flatted.stringify(data));
+          send(msg);
+          done();
+        }
+
+        const checkIdOrObject = (check) => {
+          try {
+            if (typeof check !== 'string') {
+              if (check.hasOwnProperty('id')) {
+                return check.id;
+              } else {
+                return false;
+              }
+            } else {
+              return check;
+            }
+          } catch (error) {
+            return false;
+          }
+        }
+
+        const getGuild = async (id) => {
+          const guildId = checkIdOrObject(id);
+          if (!guildId) {
+            throw (`msg.guild wasn't set correctly`);
+          }
+          return await bot.guilds.fetch(guildId);
+        }
+
+
+        const infoGuild = async () => {
+          try {
+            let guild = await getGuild(_guild)
+            setSuccess(`guild ${_guild} info obtained`, guild);
+          } catch (err) {
+            setError(err);
+          }
+        }
+
+        const setGuildName = async () => {
+
+          let guild = await getGuild(_guild)
+          let name = checkIdOrObject(_name)
+
+          if (!name) {
+            setError(`msg.name wasn't set correctly`);
+            return;
+          }
+
+          try {
+
+            guild.setName(name).then(updated => setSuccess(`Updated guild name to ${updated.name}`,updated) )
+
+          } catch (err) {
+            setError(err);
+          }
+        }
+
+    
+        switch (_action.toLowerCase()) {
+          case 'info':
+            await infoGuild();
+            break;
+          case 'name':
+              await setGuildName();
+              break; 
+          default:
+            setError(`msg.action has an incorrect value`)
+        }
+
+        node.on('close', function () {
+          discordBotManager.closeBot(bot);
+        });
+      });
+    }).catch(err => {
+      console.log(err);
+      node.status({
+        fill: "red",
+        shape: "dot",
+        text: err
+      });
+    });
+  }
+  RED.nodes.registerType("discordGuildManager", discordMessageManager);
+};

--- a/discord/discordMessageManager.html
+++ b/discord/discordMessageManager.html
@@ -41,7 +41,7 @@ a<script type="text/javascript">
     </div>
 </script>
 <script type="text/x-red" data-help-name="discordMessageManager">
-  <p>Node to send, edit or delete (embed) messages in Discord</p>
+  <p>Node to send, edit, reply, react, crosspost, obtain info, or delete messages in Discord</p>
   <p>More support can be found <a href="https://github.com/Markoudstaal/node-red-contrib-discord-advanced/wiki/discordMessageManager">here</a>.</p>
 
   <h3>Inputs</h3>
@@ -53,7 +53,7 @@ a<script type="text/javascript">
     <dt>action
       <span class="property-type">string</span>
     </dt>
-    <dd>The action to do, can be: createi, edit, delete, reply, react, corsspost, or info. If not set, node will default to create.</dd>
+    <dd>The action to do, can be: create, edit, delete, reply, react, crosspost, or info. If not set, node will default to create.</dd>
     <dt>channel
       <span class="property-type">Object or string</span>
     </dt>

--- a/discord/discordMessageManager.html
+++ b/discord/discordMessageManager.html
@@ -41,7 +41,7 @@ a<script type="text/javascript">
     </div>
 </script>
 <script type="text/x-red" data-help-name="discordMessageManager">
-  <p>Node to send, edit, reply, react, crosspost, obtain info, or delete messages in Discord</p>
+  <p>Node to send, edit, reply, react, crosspost, obtain info, search, or delete messages in Discord</p>
   <p>More support can be found <a href="https://github.com/Markoudstaal/node-red-contrib-discord-advanced/wiki/discordMessageManager">here</a>.</p>
 
   <h3>Inputs</h3>
@@ -53,7 +53,7 @@ a<script type="text/javascript">
     <dt>action
       <span class="property-type">string</span>
     </dt>
-    <dd>The action to do, can be: create, edit, delete, reply, react, crosspost, or info. If not set, node will default to create.</dd>
+    <dd>The action to do, can be: create, edit, delete, reply, react, crosspost, search, or info. If not set, node will default to create.</dd>
     <dt>channel
       <span class="property-type">Object or string</span>
     </dt>
@@ -85,7 +85,8 @@ a<script type="text/javascript">
     <dt>payload
       <span class="property-type">Object</span>
     <dt>
-    <dd>The message that was created, edited or deleted.</dd>
+    <dd>The message that was created, edited or deleted. In the case of a search, payload will be an array of messages.</dd>
+
     <dt>request
       <span class="property-type">Object</span>
     <dt>
@@ -117,6 +118,9 @@ a<script type="text/javascript">
 
   <h4>Obtaining messages</h4>
   <p>To obtain a message object given its message ID set <code>msg.action</code> to 'info'. Also <code>msg.channel</code> and <code>msg.message</code> are required. The node will then return the message if it exists.</p>
+    
+  <h4>Searching messages</h4>
+  <p>It is possible to search for messages given a channel. To search for messages set <code>msg.action</code> to 'search'. It will retrieve the last 64 messages unless overriden by <code>msg.searchLimit</code>. The search can also be filtered setting <code>msg.author</code>. Note that the search limit is applied before the filtering, e.g. in the default scenario it will not search for the last 64 messages by the user, but rather the last 64 messages and return an array containing the messages by the author.</p>
     
     
   <h4>Attachments</h4>

--- a/discord/lib/discordFramework.js
+++ b/discord/lib/discordFramework.js
@@ -1,0 +1,57 @@
+
+const { Client, GatewayIntentBits, Partials } = require('discord.js');
+
+const checkIdOrObject = (check) => {
+    try {
+        if (typeof check !== 'string') {
+        if (check.hasOwnProperty('id')) {
+            return check.id;
+        } else {
+            return false;
+        }
+        } else {
+        return check;
+        }
+    } catch (error) {
+        return false;
+    }
+}
+
+const getGuild = async (bot, id) => {
+    const guildId = checkIdOrObject(id);
+    if (!guildId) {
+        throw (`msg.guild wasn't set correctly`);
+    }
+    return await bot.guilds.fetch(guildId);
+}
+
+
+
+const getChannel = async (bot, id) => {
+    const channelID = checkIdOrObject(id);
+    if (!channelID) {
+        throw (`msg.channel wasn't set correctly`);
+    }
+    return await bot.channels.fetch(channelID);
+}
+
+const getMessage = async (bot, channel, message) => {
+    const channelID = checkIdOrObject(channel);
+    const messageID = checkIdOrObject(message);
+    if (!channelID) {
+        throw (`msg.channel wasn't set correctly`);
+    } else if (!messageID) {
+        throw (`msg.message wasn't set correctly`)
+    }
+
+    let channelInstance = await bot.channels.fetch(channelID);
+    return await channelInstance.messages.fetch(messageID);
+}
+
+module.exports = {
+    checkIdOrObject: checkIdOrObject,
+    getMessage: getMessage,
+    getGuild: getGuild,
+    getChannel: getChannel
+
+};

--- a/discord/lib/discordFramework.js
+++ b/discord/lib/discordFramework.js
@@ -1,16 +1,17 @@
 
-const { Client, GatewayIntentBits, Partials } = require('discord.js');
+const { Client, GatewayIntentBits, Partials, GuildScheduledEventManager } = require('discord.js');
 
 const checkIdOrObject = (check) => {
     try {
         if (typeof check !== 'string') {
-        if (check.hasOwnProperty('id')) {
-            return check.id;
-        } else {
-            return false;
-        }
-        } else {
-        return check;
+            if (check.hasOwnProperty('id')) {
+                return check.id;
+            } else {
+                return false;
+            }
+        } 
+        else {
+            return check;
         }
     } catch (error) {
         return false;
@@ -25,6 +26,11 @@ const getGuild = async (bot, id) => {
     return await bot.guilds.fetch(guildId);
 }
 
+const getEventManager = async (bot, id) => {
+
+    guild = await getGuild(bot,id)
+    return new GuildScheduledEventManager(guild);
+}
 
 
 const getChannel = async (bot, id) => {
@@ -52,6 +58,7 @@ module.exports = {
     checkIdOrObject: checkIdOrObject,
     getMessage: getMessage,
     getGuild: getGuild,
-    getChannel: getChannel
+    getChannel: getChannel,
+    getEventManager: getEventManager
 
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
       "discordInteraction": "discord/discordInteraction.js",
       "discordInteractionManager": "discord/discordInteractionManager.js",
       "discordTyping": "discord/discordTyping.js",
-      "discordGuildManager": "discord/discordGuildManager.js"
+      "discordGuildManager": "discord/discordGuildManager.js",
+      "discordEventManager": "discord/discordEventManager.js"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       "discordClient": "discord/discordClient.js",
       "discordInteraction": "discord/discordInteraction.js",
       "discordInteractionManager": "discord/discordInteractionManager.js",
-      "discordTyping": "discord/discordTyping.js"
+      "discordTyping": "discord/discordTyping.js",
+      "discordGuildManager": "discord/discordGuildManager.js"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Added a new node called the guild manager. Will fetch the guild given the guild info field or msg parameter. Returns the guild object per https://discord.js.org/docs/packages/discord.js/main/Guild:Class. Also added an action to rename the guild. There is the potential to perform more actions but several commands are for only boosted servers. Theoretically server icon setting is not that difficult to perform since it can be done with a URL. 