### PR TITLE
Added the discordCommandManager

### DIFF
--- a/discord/discordCommandManager.html
+++ b/discord/discordCommandManager.html
@@ -1,0 +1,75 @@
+a<script type="text/javascript">
+  RED.nodes.registerType('discordCommandManager', {
+    category: 'discord',
+    color: '#7289da',
+    defaults: {
+      name: {
+        value: "",
+        required: false
+      },
+      guild: {
+        value: null,
+        required: false
+      },
+      token: {
+        value: "",
+        required: true,
+        type: "discord-token"
+      }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: "discord.png",
+    label: function () {
+      return this.name || "discordCommandManager";
+    }
+  });
+</script>
+<script type="text/x-red" data-template-name="discordCommandManager">
+  <div class="form-row">
+        <label for="node-input-token"><i class="icon-tag"></i> token</label>
+        <input type="text" id="node-input-token" placeholder="token">
+    </div>
+    <div class="form-row">
+        <label for="node-input-guild"><i class="icon-tag"></i> Guild</label>
+        <input type="text" id="node-input-guild" name="guild" placeholder="Guild ID">
+        <p>(leave 'guild' blank to use <code>msg.guild</code> as guild ID to send to)</p>
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+<script type="text/x-red" data-help-name="discordCommandManager">
+  <p>Node to set the application commands for the bot, as well as delete specific commands or all commands, by guild or globally.</p>
+
+  <h3>Inputs</h3>
+  <dl class="message-properties">
+    <dt>action
+      <span class="property-type">string</span>
+    </dt>
+    <dd>The action to do, can be: set, or delete.</dd>
+    <dt>guild
+      <span class="property-type">Object or string</span>
+    </dt>
+    <dd>The guild object or ID.</dd>
+  </dl>
+
+  <h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>payload
+      <span class="property-type">Object</span>
+    <dt>
+    <dd>When setting the commands it will return an array of the commands created. It will be the type of the application command (https://discord.js.org/docs/packages/discord.js/14.15.3/ApplicationCommand:Class) or guild command if the guildId is set.</dd>
+  </dl>
+
+  <h3>Details</h3>
+  <p>This node can set and delete application commands.<p>
+
+  <h4>Setting commands<h4>
+  <p>To set commands simply set msg.commands to an array of the commands you'd like to set for the bot. The array objects must be of the slash command form. An example can be found using the slash command builder (https://discordjs.guide/creating-your-bot/slash-commands.html#individual-command-files). If the guild is not set then it will be applied globally, if guild is set then its applied only to that guild.</p>
+
+  <h4>Setting commands<h4>
+  <p>To delete a specific command set commandId to the id of the command you wish to be deleted (which can be found by remembering the output of the add command, or by going into server and checking the intergration, right clicking will get the application command id (https://discordjs.guide/slash-commands/deleting-commands.html#deleting-specific-commands)). Note the command Id must be in the form of a string, e.g. '123534523423423'. To delete all commands do not set msg.commandId. Similiarly to the set command, you can set a guild to delete a command in a specific guild, or by not setting guild the command will be deleted across all guilds.</p>
+
+</script>

--- a/discord/discordCommandManager.js
+++ b/discord/discordCommandManager.js
@@ -1,0 +1,247 @@
+module.exports = function (RED) {
+  var discordBotManager = require('node-red-contrib-discord-advanced/discord/lib/discordBotManager.js');
+  var messagesFormatter = require('node-red-contrib-discord-advanced/discord/lib/messagesFormatter.js');
+
+
+  const Flatted = require('flatted');
+  const { REST, Routes } = require('discord.js');
+
+  const checkString = (field) => typeof field === 'string' ? field : false;
+
+  function discordCommandManager(config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
+    var configNode = RED.nodes.getNode(config.token);
+
+    var bot = discordBotManager.getBot(configNode)
+
+    bot.then(function (bot) {
+      node.on('input', async function (msg, send, done) {
+        const _guildId = config.guild || msg.guild || null;
+        const _action = msg.action || null;
+
+        const _commands = msg.commands || null;
+        const _commandID = msg.commandId || null;
+
+      
+
+        const setError = (error) => {
+          node.status({
+            fill: "red",
+            shape: "dot",
+            text: error
+          })
+          done(error);
+        }
+
+        const setSuccess = (succesMessage, data) => {
+          node.status({
+            fill: "green",
+            shape: "dot",
+            text: succesMessage
+          });
+
+          msg.payload = Flatted.parse(Flatted.stringify(data));
+          send(msg);
+          done();
+        }
+
+        const checkIdOrObject = (check) => {
+          try {
+            if (typeof check !== 'string') {
+              if (check.hasOwnProperty('id')) {
+                return check.id;
+              } else {
+                return false;
+              }
+            } else {
+              return check;
+            }
+          } catch (error) {
+            return false;
+          }
+        }
+
+
+        const deleteCommand = async () => {
+
+          try {
+   
+            let commandId = _commandID
+
+            const rest = new REST().setToken(bot.token);
+
+            const guildId = checkIdOrObject(_guildId)
+
+            let data = null
+
+            if ( commandId != null ){
+
+              if ( guildId ) {
+
+    
+
+                data = await rest.delete(Routes.applicationGuildCommand(bot.id, guildId, commandId))
+
+              }
+              else {
+
+                data = await rest.delete(Routes.applicationCommand(bot.id, commandId))
+  
+              }
+  
+              if ( data == null ){
+  
+                setError( `Could not delete application (/) command '${commandId}'.`);
+  
+              }
+              else {
+  
+                setSuccess(`Successfully deleted application (/) command '${commandId}'.` , data );
+  
+              }
+
+            }
+            else {
+
+              if ( guildId ) {
+
+                data = await rest.put(Routes.applicationGuildCommands(bot.id, guildId), {body:[]} )
+
+              }
+              else {
+
+                data = await rest.put(Routes.applicationCommands(bot.id), {body:[]} )
+  
+              }
+  
+              if ( data == null ){
+  
+                setError( `Could not delete all application (/) commands.`);
+  
+              }
+              else {
+  
+                setSuccess(`Successfully deleted all application (/) commands.` , data );
+  
+              }
+
+            }
+
+            
+           
+            
+
+          } catch (err) {
+
+            setError(err);
+
+          }
+        }
+
+        const setCommand = async () => {
+
+
+
+          try {
+   
+            let commands = _commands
+
+            if (commands == null) {
+              setError(`msg.commands wasn't set correctly`);
+              return;
+            }
+            else {
+
+              if ( commands.length == 0 ){
+
+                setError(`msg.commands wasn't set correctly`);
+                return;
+
+              }
+
+            }
+
+            const rest = new REST().setToken(bot.token);
+
+            const guildId = checkIdOrObject(_guildId)
+
+            let data = null
+
+            if ( guildId ) {
+
+              data = await rest.put(
+                Routes.applicationGuildCommands(bot.id, guildId),
+                { body: commands },
+              );
+  
+
+            }
+            else {
+
+              data = await rest.put(
+                Routes.applicationCommands(bot.id),
+                { body: commands },
+              );
+  
+
+            }
+
+            if ( data == null ){
+
+              setError( "Could not set application commands");
+
+            }
+            else {
+
+              setSuccess(`Successfully reloaded ${data.length} application (/) commands.` , data );
+
+            }
+           
+            
+
+          } catch (err) {
+
+            setError(err);
+
+          }
+        }
+
+
+        if ( _action == null ){
+
+          setError(`msg.action has no value`)
+
+        }
+        else {
+
+          switch (_action.toLowerCase()) {
+            case 'set':
+              await setCommand();
+              break;
+            case 'delete':
+              await deleteCommand();
+              break;
+            default:
+              setError(`msg.action has an incorrect value`)
+          }
+
+        }
+
+     
+
+        node.on('close', function () {
+          discordBotManager.closeBot(bot);
+        });
+      });
+    }).catch(err => {
+      console.log(err);
+      node.status({
+        fill: "red",
+        shape: "dot",
+        text: err
+      });
+    });
+  }
+  RED.nodes.registerType("discordCommandManager", discordCommandManager);
+};

--- a/discord/lib/discordBotManager.js
+++ b/discord/lib/discordBotManager.js
@@ -24,12 +24,19 @@ var getBot = function (configNode) {
         ]
       });
       bots.set(configNode, bot);
+      bot.token = configNode.token
       bot.numReferences = (bot.numReferences || 0) + 1;
-      bot.login(configNode.token).then(function () {
-        resolve(bot);
-      }).catch(function (err) {
-        reject(err);
-      });
+      bot.login(configNode.token)
+        .then(() => {
+          return bot.application.fetch(); // Fetch the application to get the ID
+        })
+        .then((app) => {
+          bot.id = app.id; // Set the application ID as a property on the bot object
+          resolve(bot);
+        })
+        .catch((err) => {
+          reject(err);
+        });
     } else {
       bot = bots.get(configNode);
       bot.numReferences = (bot.numReferences || 0) + 1;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "discordInteractionManager": "discord/discordInteractionManager.js",
       "discordTyping": "discord/discordTyping.js",
       "discordGuildManager": "discord/discordGuildManager.js",
-      "discordEventManager": "discord/discordEventManager.js"
+      "discordEventManager": "discord/discordEventManager.js",
+      "discordCommandManager": "discord/discordCommandManager.js"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
I have added a command manager to set the application commands globally or by guild, as well as delete commands globally by guild. 

Minor modification as made to the bot manager to get the ID and token for the push command. 

Setting commands can be done by using msg.commands, e.g.

var pingCommand = new SlashCommandBuilder()
	.setName('bloop')
	.setDescription('Replies with bloop!');

msg.commands = [ pingCommand ]

msg.action = "set"

Deleting commands can be done by setting the commandId, e.g.

msg.action = "delete"
msg.commandId = "181512451821"


It respects msg.guild, so it can delete/set per guild or globally if msg.guild is not set.
