### PR TITLE
Remove global BigInt serialiser replacement

### DIFF
--- a/discord/lib/discordBotManager.js
+++ b/discord/lib/discordBotManager.js
@@ -1,5 +1,4 @@
 const { Client, GatewayIntentBits, Partials } = require('discord.js');
-require('./bigint-compat');
 
 var bots = new Map();
 var getBot = function (configNode) {


### PR DESCRIPTION
This is for https://github.com/Markoudstaal/node-red-contrib-discord-advanced/issues/130

I couldn't find what this code was doing. I understand that BigInts, for channel IDs and such loose some digits when serialising them with `JSON.stringify()`, but in all cases I tested with, all these large numbers were already strings.

The reason to remove this include is due to it replacing the global serialiser, which is breaking other things which expect BigInts to not be strings.